### PR TITLE
Restored log watching functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # AMII Changelog
 
+## [0.10.1]
+
+## Fixed
+
+- The log watching functionality not watching logs.
+
 ## [0.10.0]
 
 ### Added

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,9 +1,12 @@
 ### Added
 
 - The ability to mildly disappoint MIKU if you start to mess up a bit. They understand, but you got to fix your stuff.
+
+
 ![Ya dun messed up](https://amii.assets.unthrottled.io/visuals/pouting/miku_pout_kimono.gif)
 
 
 ### Fixed
 
 - Poor offline user experience. No longer propagating exceptions when offline. Thanks for reporting the exceptions!
+- The log watching functionality not watching logs.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = io.unthrottled
 pluginName_ = Anime Memes
-pluginVersion = 0.10.0
+pluginVersion = 0.10.1
 pluginSinceBuild = 202.6397.94
 pluginUntilBuild = 211.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
@@ -25,6 +25,7 @@ private fun buildUpdateMessage(updateAsset: String): String =
       <ul>
         <li>You can now mildly disappoint MIKU.</li>
         <li>Added better offline user experience</li>
+        <li>Restored Log Watching Feature</li>
       </ul>
       <br>See the <a href="https://github.com/ani-memes/AMII#documentation">documentation</a> for features, usages, and configurations.
       <br>The <a href="https://github.com/ani-memes/AMII/blob/master/CHANGELOG.md">changelog</a> is available for more details.

--- a/src/main/kotlin/io/unthrottled/amii/services/ConsoleFilterFactory.kt
+++ b/src/main/kotlin/io/unthrottled/amii/services/ConsoleFilterFactory.kt
@@ -2,7 +2,6 @@ package io.unthrottled.amii.services
 
 import com.intellij.execution.filters.Filter
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import io.unthrottled.amii.config.Config
 import io.unthrottled.amii.config.ConfigListener
@@ -29,7 +28,7 @@ class ConsoleFilterFactory(
   private var keyword = Config.instance.logSearchTerms
   private var ignoreCase = Config.instance.logSearchIgnoreCase
 
-  private val messageBusConnection = ApplicationManager.getApplication().messageBus.connect()
+  private val messageBusConnection = project.messageBus.connect()
 
   init {
     messageBusConnection.subscribe(


### PR DESCRIPTION
# Changes

- Actually listening to process started events, that way can listen to logs for processes that are actively running.

# Motivation

Closes #109 