### PR TITLE
Added support for users with an ' in their path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 # AMII Changelog
 
+## [0.13.1]
+
+### Fixed
+
+- Images not showing up for users with an `'` in their file path.
+
 ## [0.13.0]
 
 ### Added

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,12 +1,3 @@
-### Added
-
-- The ability to view information about the source of a meme on click.
-- `Show Previous Meme`: an action that shows the previously shown meme.
-- `Discreet Mode`, when enabled MIKU will clear and not show _any_ anime in the IDE. Also, the mood in the status bar
-  will temporarily hide as well.
-- Added 2021.3 Build support. Plugin only supports 2020.3+ builds now.
-
 ### Fixed
 
-- The settings UI overflow issues, that prevented all content from being seen. (I can scrollbar better)
-- Minor issue with plugin attempting to dismiss active memes. ([#123](https://github.com/ani-memes/AMII/issues/123))
+- Images not showing up for users with an `'` in their file path.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = io.unthrottled
 pluginName_ = Anime Memes
-pluginVersion = 0.13.0
+pluginVersion = 0.13.1
 pluginSinceBuild = 203.7148.57
 pluginUntilBuild = 213.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
+++ b/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
@@ -272,7 +272,7 @@ class MemePanel(
 
     @Language("HTML")
     val stickerHTML = """<html>
-           <img src='${visualMeme.filePath}' alt='${visualMeme.imageAlt}' $extraStyles />
+           <img src='${getFileUrl()}' alt='${visualMeme.imageAlt}' $extraStyles />
          </html>
     """.trimIndent()
     val memeDisplay = JBLabel(
@@ -295,6 +295,8 @@ class MemePanel(
 
     return memeContent to memeDisplay
   }
+
+  private fun getFileUrl() = visualMeme.filePath.toString().replace("'", "%27")
 
   private fun getExtraStyles(): String =
     if (Config.instance.capDimensions) {

--- a/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
@@ -22,11 +22,7 @@ private fun buildUpdateMessage(updateAsset: String): String =
   """
       What's New?<br>
       <ul>
-        <li>Added Integrated Discreet Mode</li>
-        <li>Click Meme to show info!</li>
-        <li>Show Previous Meme action.</li>
-        <li>2021.3 Build Support</li>
-        <li>Handling vertical overflow better in settings UI</li>
+        <li>Added support for users with an ' in their path</li>
       </ul>
       <br>See the <a href="https://github.com/ani-memes/AMII#documentation">documentation</a> for features, usages, and configurations.
       <br>The <a href="https://github.com/ani-memes/AMII/blob/master/CHANGELOG.md">changelog</a> is available for more details.


### PR DESCRIPTION
## Changes

### Fixed

- Images not showing up for users with an `'` in their file path.

## Motivation

Closes #135 

## Notes

I also tested 汉字 in the path, and it was fine, so the `'` was the jerk.