### PR TITLE
2022.1 build support & View Meme Source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 # AMII Changelog
 
+## [0.14.0]
+
+### Added
+
+- 2022.1 Build Support
+- The ability to right-click a meme view to the meme's asset source page on https://amii-assets.unthrottled.io/
+
 ## [0.13.2]
 
 ## Fixed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,9 +7,9 @@ fun properties(key: String) = project.findProperty(key).toString()
 
 plugins {
   // Kotlin support
-  id("org.jetbrains.kotlin.jvm") version "1.4.32"
+  id("org.jetbrains.kotlin.jvm") version "1.6.0"
   // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-  id("org.jetbrains.intellij") version "1.1.4"
+  id("org.jetbrains.intellij") version "1.2.0"
   // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
   id("org.jetbrains.changelog") version "1.1.2"
   // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
@@ -91,17 +91,16 @@ detekt {
 }
 
 tasks {
-  // Set the compatibility versions to 1.8
   withType<JavaCompile> {
-    sourceCompatibility = "1.8"
-    targetCompatibility = "1.8"
+    sourceCompatibility = "11"
+    targetCompatibility = "11"
   }
   withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
+    kotlinOptions.jvmTarget = "11"
   }
 
   withType<Detekt> {
-    jvmTarget = "1.8"
+    jvmTarget = "11"
   }
 
   runIde {

--- a/docs/RELEASE-NOTES.md
+++ b/docs/RELEASE-NOTES.md
@@ -1,3 +1,8 @@
+### Added
+
+- 2022.1 Build Support
+- The ability to right-click a meme view to the meme's asset source page on https://amii-assets.unthrottled.io/
+
 ### Fixed
 
 - Images not showing up for users with an `'` in their file path.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = io.unthrottled
 pluginName_ = Anime Memes
-pluginVersion = 0.13.2
+pluginVersion = 0.14.0
 pluginSinceBuild = 203.7148.57
 pluginUntilBuild = 221.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,17 +5,17 @@ pluginGroup = io.unthrottled
 pluginName_ = Anime Memes
 pluginVersion = 0.13.2
 pluginSinceBuild = 203.7148.57
-pluginUntilBuild = 213.*
+pluginUntilBuild = 221.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions = 2020.3.2,2021.1,2021.2
 
-platformType = IC
-platformVersion = 2021.2
+platformType = IU
+platformVersion = LATEST-EAP-SNAPSHOT
 platformDownloadSources = true
 # Plugin Dependencies -> https://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_dependencies.html
 # Example: platformPlugins = com.intellij.java,com.jetbrains.php:203.4449.22
-platformPlugins = io.acari.DDLCTheme:21.0.0
+platformPlugins = io.acari.DDLCTheme:74.1-1.0.0
 
 idePath=
 #idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/AndroidStudio/ch-0/203.7321754

--- a/src/main/kotlin/io/unthrottled/amii/memes/Meme.kt
+++ b/src/main/kotlin/io/unthrottled/amii/memes/Meme.kt
@@ -158,9 +158,11 @@ class Meme(
             ) {
               project.memeInfoService().displayInfo(visualMemeContent)
             } else if (clickEvent == ClickEvent.RIGHT) {
-              BrowserUtil.browse("https://amii-assets.unthrottled.io/assets/view/${
+              BrowserUtil.browse(
+                "https://amii-assets.unthrottled.io/assets/view/${
                 memePanel.visualMeme.id
-              }")
+                }"
+              )
             }
           }
 

--- a/src/main/kotlin/io/unthrottled/amii/memes/Meme.kt
+++ b/src/main/kotlin/io/unthrottled/amii/memes/Meme.kt
@@ -1,5 +1,6 @@
 package io.unthrottled.amii.memes
 
+import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
@@ -35,7 +36,7 @@ interface MemeLifecycleListener {
   // user triggered event
   fun onDismiss() {}
 
-  fun onClick() {}
+  fun onClick(clickEvent: ClickEvent) {}
 
   fun onRemoval() {}
 
@@ -150,9 +151,16 @@ class Meme(
             }
           }
 
-          override fun onClick() {
-            if (ApplicationManager.getApplication().getConfig().infoOnClick) {
+          override fun onClick(clickEvent: ClickEvent) {
+            if (
+              ApplicationManager.getApplication().getConfig().infoOnClick &&
+              clickEvent == ClickEvent.LEFT
+            ) {
               project.memeInfoService().displayInfo(visualMemeContent)
+            } else if (clickEvent == ClickEvent.RIGHT) {
+              BrowserUtil.browse("https://amii-assets.unthrottled.io/assets/view/${
+                memePanel.visualMeme.id
+              }")
             }
           }
 

--- a/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
+++ b/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
@@ -61,6 +61,10 @@ import javax.swing.MenuElement
 import javax.swing.SwingUtilities
 import kotlin.math.max
 
+enum class ClickEvent {
+  LEFT, RIGHT, UNKNOWN
+}
+
 enum class PanelDismissalOptions {
   FOCUS_LOSS, TIMED;
 
@@ -179,7 +183,13 @@ class MemePanel(
           } else if (wasInside) {
             fadeoutAlarm.cancelAllRequests()
             clickedInside = true
-            this.lifecycleListener.onClick()
+            this.lifecycleListener.onClick(
+              when {
+                SwingUtilities.isLeftMouseButton(event) -> ClickEvent.LEFT
+                SwingUtilities.isRightMouseButton(event) -> ClickEvent.RIGHT
+                else -> ClickEvent.UNKNOWN
+              }
+            )
           }
         }
       } else if (

--- a/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
+++ b/src/main/kotlin/io/unthrottled/amii/memes/MemePanel.kt
@@ -163,6 +163,7 @@ class MemePanel(
     )
   }
 
+  @Suppress("ComplexMethod") // cuz I said so.
   private fun createMouseListener(): AWTEventListener {
     var clickedInside = false
     return AWTEventListener { event ->

--- a/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
+++ b/src/main/kotlin/io/unthrottled/amii/onboarding/UpdateNotification.kt
@@ -22,6 +22,8 @@ private fun buildUpdateMessage(updateAsset: String): String =
   """
       What's New?<br>
       <ul>
+        <li>2022.1 Build Support.</li>
+        <li>Right-click an active meme to view asset manager source.</li>
         <li>Added support for users with an ' in their path</li>
         <li>Fixed issue with dimension capping of assets.</li>
       </ul>


### PR DESCRIPTION
# Changes

### Added

- 2022.1 Build Support
- The ability to right-click a meme view to the meme's asset source page on https://amii-assets.unthrottled.io/

# Motivation

Closes #139 

Also because I've been using 2022.1 all week, I miss my anime content 😢 