### PR TITLE
bump version support and fix displayNane exception

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
 
       - name: Fetch Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v1.0.3
+        uses: gradle/wrapper-validation-action@v1.1.0
 
   # Run verifyPlugin and test Gradle tasks
   test:
@@ -39,22 +39,22 @@ jobs:
     steps:
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
 
       - name: Fetch Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Gradle Dependencies Cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', 'gradle.properties') }}
 
       - name: Setup Gradle Wrapper Cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
@@ -78,22 +78,22 @@ jobs:
     steps:
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
 
       - name: Fetch Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Gradle Dependencies Cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', 'gradle.properties') }}
 
       - name: Setup Gradle Wrapper Cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
@@ -107,16 +107,16 @@ jobs:
           NAME="$(echo "$PROPERTIES" | grep "^pluginName_:" | cut -f2- -d ' ')"
           ARTIFACT="${NAME}-${VERSION}.zip"
 
-          echo "::set-output name=version::$VERSION"
-          echo "::set-output name=name::$NAME"
-          echo "::set-output name=artifact::$ARTIFACT"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "name=${NAME}" >> $GITHUB_OUTPUT
+          echo "artifact=${ARTIFACT}" >> $GITHUB_OUTPUT
 
       - name: Build Plugin
         run: ./gradlew buildPlugin
 
       # Upload plugin artifact to make it available in the next jobs
       - name: Upload artifact
-        uses: actions/upload-artifact@v2.2.3
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: plugin-artifact
           path: ./build/distributions/${{ needs.build.outputs.artifact }}
@@ -130,22 +130,22 @@ jobs:
     steps:
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'zulu'
 
       - name: Fetch Sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Gradle Dependencies Cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle', '**/*.gradle.kts', 'gradle.properties') }}
 
       - name: Setup Gradle Wrapper Cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.3.2
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
@@ -158,12 +158,12 @@ jobs:
           PROPERTIES="$(./gradlew properties --console=plain -q)"
           IDE_VERSIONS="$(echo "$PROPERTIES" | grep "^pluginVerifierIdeVersions:" | base64)"
 
-          echo "::set-output name=ideVersions::$IDE_VERSIONS"
-          echo "::set-output name=pluginVerifierHomeDir::~/.pluginVerifier"
+          echo "ideVersions=${IDE_VERSIONS}" >> $GITHUB_OUTPUT
+          echo "pluginVerifierHomeDir=~/.pluginVerifier" >> $GITHUB_OUTPUT
 
       # Cache Plugin Verifier IDEs
       - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@v2.1.4
+        uses: actions/cache@v3.3.2
         with:
           path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
           key: ${{ runner.os }}-plugin-verifier-${{ steps.properties.outputs.ideVersions }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginSinceBuild = 231
 pluginUntilBuild = 233.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.2.1
+pluginVerifierIdeVersions = 2023.3
 
 platformType = IU
 platformVersion = 2023.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ pluginGroup = io.unthrottled
 pluginName_ = Anime Memes
 pluginVersion = 1.1.8
 pluginSinceBuild = 231
-pluginUntilBuild = 232.*
+pluginUntilBuild = 233.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions = 2023.2.1

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -29,7 +29,8 @@
     <applicationService serviceImplementation="io.unthrottled.amii.assets.VisualAssetProbabilityService"/>
     <applicationService serviceImplementation="io.unthrottled.amii.promotion.NormieService"
                         serviceInterface="io.unthrottled.amii.promotion.SpecialSnowflakeService"/>
-    <applicationConfigurable id="io.unthrottled.amii.config.ui.PluginSettingsUI"
+    <applicationConfigurable displayName="Anime Memes"
+                             id="io.unthrottled.amii.config.ui.PluginSettingsUI"
                              instance="io.unthrottled.amii.config.ui.PluginSettingsUI"
     />
     <consoleFilterProvider implementation="io.unthrottled.amii.listeners.ConsoleListener"/>


### PR DESCRIPTION
# Description
1. I raised supported version to `223.*`. #174 
2. I fixed the exception error showed up when setting window is opened. issue: #172 
  - ref: https://youtrack.jetbrains.com/issue/MPS-35957/com.intellij.diagnostic.PluginException-No-display-name-is-specified-for-configurable
3. bump versions of actions using deprecated functions and nodejs 12.

# Tests
I build the plugin locally, and then install it on my computer (macbook 13" m1 chip, WebStorm 2023.3).
It runs without errors.